### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.38</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
 
@@ -33,8 +33,7 @@
   <properties>
     <revision>3.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.348</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -55,8 +54,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
-        <version>1210.vcd41f6657f03</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1382.v7d694476f340</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Mainly making sure this is only offered to very recent core versions: https://github.com/jenkinsci/jenkins/pull/6570#discussion_r873861316. As in #21, using an incremental version is not permitted, so before releasing 3.1 I would need to put a temporary block on that version in the UC.
