### PR TITLE
[JEP-230] [JENKINS-55582] Set the baseline to be 2.357 where this plugin was split

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,5 @@
 // TODO can simplify once buildPlugin defaults to use JDK 11
-buildPlugin(configurations: [jdk: 11])
+buildPlugin(configurations: [
+    [jdk: 11, platform: 'linux'],
+    [jdk: 11, platform: 'windows'],
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
-// Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+// TODO can simplify once buildPlugin defaults to use JDK 11
+buildPlugin(configurations: [jdk: 11])

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <revision>3.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.348</jenkins.version>
+    <jenkins.version>2.357</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/6585 follow-up. See https://github.com/jenkinsci/acceptance-test-harness/issues/796#issuecomment-1167516594. Enables this plugin to actually be exposed normally on the update center.