### PR TITLE
Require Jenkins 2.479.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.361</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <version>4228.v0a_71308d905b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/test/java/org/jenkinsci/main/modules/instance_identity/ReadWriteKeyTest.java
+++ b/src/test/java/org/jenkinsci/main/modules/instance_identity/ReadWriteKeyTest.java
@@ -33,7 +33,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.Security;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -54,19 +53,19 @@ public class ReadWriteKeyTest {
 
     @BeforeClass
     public static void setUpBC() throws URISyntaxException, IOException {
-        PEM_PCKS1_FILE = Paths.get(ReadWriteKeyTest.class
+        PEM_PCKS1_FILE = Path.of(ReadWriteKeyTest.class
                 .getClassLoader()
                 .getResource("private-key-pcks1.pem")
                 .toURI());
-        PEM_PCKS8_FILE = Paths.get(ReadWriteKeyTest.class
+        PEM_PCKS8_FILE = Path.of(ReadWriteKeyTest.class
                 .getClassLoader()
                 .getResource("private-key-pcks8.pem")
                 .toURI());
-        KEY_PRIVATE_ENCODED = Files.readAllBytes(Paths.get(ReadWriteKeyTest.class
+        KEY_PRIVATE_ENCODED = Files.readAllBytes(Path.of(ReadWriteKeyTest.class
                 .getClassLoader()
                 .getResource("private-key-private-encoded.bin")
                 .toURI()));
-        KEY_PUBLIC_ENCODED = Files.readAllBytes(Paths.get(ReadWriteKeyTest.class
+        KEY_PUBLIC_ENCODED = Files.readAllBytes(Path.of(ReadWriteKeyTest.class
                 .getClassLoader()
                 .getResource("private-key-public-encoded.bin")
                 .toURI()));


### PR DESCRIPTION
## Require Jenkins 2.479.3 or newer (Java 17)

The upgrade to Jenkins 2.479.3 helps us prepare to remove portions of the Java EE 8 / Spring Security 5 compatibillity layer that was included in the Spring Security 6 Upgrade project.  It also allows us to use Java 17 language features.

- Bump org.jenkins-ci.plugins:plugin from 4.88 to 5.7
- Require Jenkins 2.479.3 or newer
- Use Java 11 Path.of() instead of Java 7 Paths.get()

Replaces pull request:

* #125

### Testing done

Confirmed that automated tests pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
